### PR TITLE
Bugfix/input layout

### DIFF
--- a/src/main/resources/templates/fragments/inputField.html
+++ b/src/main/resources/templates/fragments/inputField.html
@@ -5,42 +5,47 @@
 <!--@link https://github.com/spring-projects/spring-petclinic/blob/master/src/main/resources/templates/fragments/inputField.html-->
 <body>
 <form>
-    <th:block th:fragment="input (label, name, placeholder, type)">
+    <th:block th:fragment="simple (label, name, placeholder, type)">
+        <!--th:fragment="input (label,name, placeholder, type)"-->
         <div class="form-horizontal row py-2">
             <label class="col-md-2 col-form-label" th:text="${label}">Label</label>
             <div class="col-md-10"
                  th:switch="__${type}__">
+                <div th:case="date" class="input-group mb-4">
                     <!--<input th:case="date">-->
-                    <div th:case="date" class="input-group mb-4">
-                        <input class="form-control" type="text"
-                               th:placeholder="${placeholder}"
-                               th:field="*{__${name}__}"
-                               readonly id="datepicker">
-                        <div class="input-group-append">
-                            <span class="fa fa-calendar input-group-text end_date_calendar" aria-hidden="true "></span>
-                        </div>
+                    <input class="form-control" type="text"
+                           th:placeholder="${placeholder}"
+                           th:field="*{__${name}__}"
+                           readonly id="datepicker"/>
+                    <div class="input-group-append">
+                        <span class="fa fa-calendar input-group-text end_date_calendar" aria-hidden="true "></span>
                     </div>
-                    <input th:case="*" class="form-control" type="text"
+                </div>
+                <div th:case="*">
+                    <!--<input th:case="*">-->
+                    <input class="form-control" type="text"
                            th:field="*{__${name}__}"
                            th:type="${type}"
-                           th:placeholder="${placeholder}">
+                           th:placeholder="${placeholder}"/>
                 </div>
+            </div>
 
-                <!--Validation error-->
-                <p class="text-danger mb-2" th:errors="*{__${name}__}">Error</p>
+            <!--Validation error th:fragment="input"-->
+            <p class="text-danger mb-2" th:errors="*{__${name}__}">Error</p>
         </div>
     </th:block>
-      <th:block th:fragment="inputLabelTop (label, name, placeholder, type)">
-          <div class=" col-md-6 form-group">
-              <label th:text="${label}"></label>
-              <input class="form-control" type="text"
-                                         th:field="*{__${name}__}"
-                                         th:type="${type}"
-                                         th:placeholder="${placeholder}" />
-              <!--Validation error-->
-              <p class="text-danger mb-2" th:errors="*{__${name}__}">Error</p>
-</div>
-</th:block>
+    <th:block th:fragment="labelTop (label, name, placeholder, type)">
+        <!--th:fragment="inputLabelTop (label, name, placeholder, type)"-->
+        <div class=" col-md-6 form-group">
+            <label th:text="${label}"></label>
+            <input class="form-control" type="text"
+                   th:field="*{__${name}__}"
+                   th:type="${type}"
+                   th:placeholder="${placeholder}"/>
+            <!--Validation error th:fragment="inputLabelTop"-->
+            <p class="text-danger mb-2" th:errors="*{__${name}__}">Error</p>
+        </div>
+    </th:block>
 
 </form>
 </body>

--- a/src/main/resources/templates/pages/despesa/details.html
+++ b/src/main/resources/templates/pages/despesa/details.html
@@ -35,9 +35,9 @@
                     <div class="card-body">
                         <form th:object="${entity}">
                             <div class="col-md-12 col-sm-12 col-xs-12">
-                                <input th:replace="~{fragments/inputField :: input ('Descrição', 'descricao', 'Descrição', 'text')}" />
-                                <input th:replace="~{fragments/inputField :: input ('Valor', 'valor', 'Valor', 'number')}" />
-                                <input th:replace="~{fragments/inputField :: input ('Data', 'data', 'Data', 'date')}" />
+                               <input th:replace="~{fragments/inputField :: simple ('Descrição', 'descricao', 'Descrição', 'text')}" />
+                               <input th:replace="~{fragments/inputField :: simple ('Valor', 'valor', 'Valor', 'number')}" />
+                               <input th:replace="~{fragments/inputField :: simple ('Data', 'data', 'Data', 'date')}" />
                             </div>
                             <a th:href="@{/admin/despesas/{id}/edit(id=${entity.id})}" class="btn btn-primary">Editar
                                 Despesa</a>

--- a/src/main/resources/templates/pages/despesa/form.html
+++ b/src/main/resources/templates/pages/despesa/form.html
@@ -36,9 +36,9 @@
                         <!--/*@thymesVar id="entity" type="br.com.uece.frameworks.stockfy.model.Fornecedor"*/-->
                         <form class="form-horizontal" th:object="${entity}" method="post">
 
-                            <input th:replace="~{fragments/inputField :: input ('Descrição', 'descricao', 'Descrição', 'text')}" />
-                            <input th:replace="~{fragments/inputField :: input ('Valor', 'valor', 'Valor', 'number')}" />
-                            <input th:replace="~{fragments/inputField :: input ('Data', 'data', 'Data', 'date')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('Descrição', 'descricao', 'Descrição', 'text')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('Valor', 'valor', 'Valor', 'number')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('Data', 'data', 'Data', 'date')}" />
                             <!--<div class="end_date input-group mb-4">-->
                                 <!--<input class="form-control" type="text" placeholder="" readonly id="datepicker">-->
                                 <!--<div class="input-group-append">-->

--- a/src/main/resources/templates/pages/estabelecimento/form.html
+++ b/src/main/resources/templates/pages/estabelecimento/form.html
@@ -33,16 +33,16 @@
                         <strong>Basic Form</strong> Estabelecimentos</div>
                     <div class="card-body">
                         <form class="form-group form-horizontal input_mask" th:object="${entity}" method="post">
-                            <div class="col-md-12 col-sm-12 col-xs-12">
+                            <div class="col-md-12 col-sm-12 col-xs-12 px-0">
                                 <div class="row">
-                                    <div class="col-md-6 col-sm-6 col-xs-6">
+                                    <div class="col-md-6 col-sm-6 col-xs-6 px-0">
                                         <div class="col-md-2 col-form-label">Nome</div>
                                         <div class="col-md-10">
                                             <input class="form-control" type="text" placeholder="Nome" th:field="*{nome}" />
                                             <p class="text-danger mb-2" th:errors="*{nome}"></p>
                                         </div>
                                     </div>
-                                    <div class="col-md-6 col-sm-6 col-xs-6">
+                                    <div class="col-md-6 col-sm-6 col-xs-6 px-0">
                                         <div class="col-md-2 col-form-label">CNPJ</div>
                                         <div class="col-md-10">
                                             <input class="form-control" type="text" th:field="*{cnpj}" />

--- a/src/main/resources/templates/pages/fornecedor/form.html
+++ b/src/main/resources/templates/pages/fornecedor/form.html
@@ -36,11 +36,11 @@
                         <!--/*@thymesVar id="entity" type="br.com.uece.frameworks.stockfy.model.Fornecedor"*/-->
                         <form class="form-horizontal" th:object="${entity}" method="post">
 
-                            <input th:replace="~{fragments/inputField :: input ('Nome', 'nome', 'Digite um nome para o fornecedor', 'text')}" />
-                            <input th:replace="~{fragments/inputField :: input ('CNPJ', 'cnpj', 'Digite um CNPJ para o fornecedor', 'text')}" />
-                            <input th:replace="~{fragments/inputField :: input ('E-mail', 'email', 'Digite um e-mail para o fornecedor', 'email')}" />
-                            <input th:replace="~{fragments/inputField :: input ('Telefone principal', 'telefone1', 'Digite um telefone para o fornecedor', 'tel')}" />
-                            <input th:replace="~{fragments/inputField :: input ('Telefone secundário', 'telefone2', 'Digite um telefone para o fornecedor', 'tel')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('Nome', 'nome', 'Digite um nome para o fornecedor', 'text')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('CNPJ', 'cnpj', 'Digite um CNPJ para o fornecedor', 'text')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('E-mail', 'email', 'Digite um e-mail para o fornecedor', 'email')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('Telefone principal', 'telefone1', 'Digite um telefone para o fornecedor', 'tel')}" />
+                           <input th:replace="~{fragments/inputField :: simple ('Telefone secundário', 'telefone2', 'Digite um telefone para o fornecedor', 'tel')}" />
 
                             <div class="card-footer">
                                 <button class="btn btn-sm btn-primary" type="submit">

--- a/src/main/resources/templates/pages/produto/details.html
+++ b/src/main/resources/templates/pages/produto/details.html
@@ -45,10 +45,10 @@
                                     </div>
                                     <div class="col-md-8 col-sm-8 col-xs-6">
                                         <div class="row form-group">
-                                            <input th:replace="~{fragments/inputField :: inputLabelTop ('Referência', 'referencia', 'Digite uma referência', 'number')}" />
-                                            <input th:replace="~{fragments/inputField :: inputLabelTop ('Descrição', 'descricao', 'Digite a descrição', 'text')}" />
-                                            <input th:replace="~{fragments/inputField :: inputLabelTop ('Preço', 'preco', 'R$', 'number')}" />
-                                            <input th:replace="~{fragments/inputField :: inputLabelTop ('Estoque mínimo', 'estoqueMinimo', 'Digite uma quantidade', 'number')}" />
+                                            <input th:replace="~{fragments/inputField :: labelTop ('Referência', 'referencia', 'Digite uma referência', 'number')}" />
+                                            <input th:replace="~{fragments/inputField :: labelTop ('Descrição', 'descricao', 'Digite a descrição', 'text')}" />
+                                            <input th:replace="~{fragments/inputField :: labelTop ('Preço', 'preco', 'R$', 'number')}" />
+                                            <input th:replace="~{fragments/inputField :: labelTop ('Estoque mínimo', 'estoqueMinimo', 'Digite uma quantidade', 'number')}" />
                                             <div class="col-md-4 col-sm-4 col-xs-12 form-group">
                                                 <label>Categoria:</label>
                                                 <select th:field="*{categoria}" class="form-control">

--- a/src/main/resources/templates/pages/produto/form.html
+++ b/src/main/resources/templates/pages/produto/form.html
@@ -44,10 +44,10 @@
                                 <div class="col-md-8 col-sm-8 col-xs-6">
                                     <div class="row form-group">
                                         <input type="number" hidden="hidden" th:field="*{id}" class="idProduto"/>
-                                        <input th:replace="~{fragments/inputField :: inputLabelTop ('Referência', 'referencia', 'Digite uma referência', 'number')}" />
-                                        <input th:replace="~{fragments/inputField :: inputLabelTop ('Descrição', 'descricao', 'Digite a descrição', 'text')}" />
-                                        <input th:replace="~{fragments/inputField :: inputLabelTop ('Preço', 'preco', 'R$', 'number')}" />
-                                        <input th:replace="~{fragments/inputField :: inputLabelTop ('Estoque mínimo', 'estoqueMinimo', 'Digite uma quantidade', 'number')}" />
+                                        <input th:replace="~{fragments/inputField :: labelTop ('Referência', 'referencia', 'Digite uma referência', 'number')}" />
+                                        <input th:replace="~{fragments/inputField :: labelTop ('Descrição', 'descricao', 'Digite a descrição', 'text')}" />
+                                        <input th:replace="~{fragments/inputField :: labelTop ('Preço', 'preco', 'R$', 'number')}" />
+                                        <input th:replace="~{fragments/inputField :: labelTop ('Estoque mínimo', 'estoqueMinimo', 'Digite uma quantidade', 'number')}" />
                                         <div class="col-md-4 col-sm-4 col-xs-12 form-group">
                                             <label>Categoria:</label>
                                             <select th:field="*{categoria}" class="form-control">


### PR DESCRIPTION
Fix Fragments of the same html type being duplicated. 

> Actually, after reading the Thymeleaf documentation on the fragment selector syntax, the part after the :: is a generic DOM selector, which can be a fragment name, or:
DOM Selector syntax is similar to XPath expressions and CSS selectors
So we've got it matching on the fragment name and the result of a CSS selector. Knowing this, you should rename your fragments so they don't clash with HTML element names.
[ultraq commented on 4 Aug 2014](https://github.com/ultraq/thymeleaf-layout-dialect/issues/48#issuecomment-51025070)